### PR TITLE
Fix sitemap builder completion tracking and admin view display

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ A gamified project management system specifically designed for Aloa web design p
 - **Quick Actions**: Add projectlets and applets without leaving the management view
 - **Applet Library**: Pre-built applet templates for common tasks
 
+### Applet System & Admin Interface
+- **Collapsed View Display**: All applets display completion avatars in the collapsed view (right side, next to trash icon)
+- **Clickable Avatars**: Standard behavior - clicking any completion avatar opens a modal showing that user's submitted data
+  - Form applets: Shows the user's form responses
+  - Palette Cleanser applets: Shows the user's palette preferences
+  - Sitemap applets: Shows the user's submitted sitemap structure
+- **Visual Status Indicators**:
+  - Solid ring: Completed submission
+  - Dashed ring: In-progress submission
+- **Clean Interface**: Applets remain collapsed with inline configuration when expanded
+- **Consistent UX**: All applet types follow the same interaction pattern for viewing user submissions
+
 ### Enhanced File Repository
 - **Hierarchical Folder Structure**: Create nested folders to organize project files
 - **Drag & Drop File Management**: Move files between folders with intuitive drag and drop
@@ -291,7 +303,40 @@ The system guides projects through these phases:
 - ❌ `/api/forms/*` - Old form system, do not use
 - ❌ `/api/responses/*` - Old response system, do not use
 
-## Development
+## Development Best Practices
+
+### ⚠️ Preventing Regressions When Adding New Applets
+
+When developing new applet types, follow these guidelines to avoid breaking existing functionality:
+
+#### 1. File Handling Standards
+- **Always use underscored property names**: `file_name`, `file_size`, `file_url` (NOT `fileName`, `size`, `url`)
+- **Check multiple storage locations**: Files can be in `config.files`, `config.attached_files`, or `aloa_project_files` table
+- **Add null checks**: Always check if properties exist before using methods like `.split()` or `.toLowerCase()`
+- **Handle API response formats**: Support both array responses and `{ files: [...] }` object responses
+
+#### 2. Progress Tracking Standards
+- **Use standardized progress system**: All applets MUST use `aloa_applet_progress` table
+- **Update via stored procedure**: Call `update_applet_progress` through `/api/aloa-projects/[projectId]/client-view`
+- **Track key timestamps**: Always set `started_at` and `completed_at` appropriately
+- **Button state logic**: "Start" → "Resume" → "Edit/View" based on progress timestamps
+
+#### 3. Testing Checklist Before Committing
+Before pushing any new applet work:
+- [ ] Test File Repository still loads without errors
+- [ ] Test existing upload applets (Pig/Agency Upload) still display files
+- [ ] Test Palette Cleanser shows correct button states
+- [ ] Test file sizes display correctly (not 0 bytes)
+- [ ] Test both admin and client dashboards for runtime errors
+- [ ] Check browser console for any JavaScript errors
+
+#### 4. Common Pitfalls to Avoid
+- Don't assume file properties exist - always use fallbacks
+- Don't hardcode property names - use consistent naming across components
+- Don't modify shared components without testing all usages
+- Don't change API response formats without updating all consumers
+
+### Development Commands
 
 ```bash
 npm run dev    # Start development server
@@ -308,7 +353,16 @@ Optimized for Vercel:
 3. Add environment variables
 4. Deploy
 
-## Recent Updates (January 2025)
+## Recent Updates (December 2024)
+
+### 🔧 File Handling Fixes & Improvements
+- **Fixed File Upload Applets**: Restored functionality for Pig/Agency Upload applets to display attached files correctly
+- **Fixed Palette Cleanser**: Now properly shows "Resume" button for in-progress users instead of "Start"
+- **Fixed File Repository**: Resolved "Failed to load files" error with proper API response handling
+- **Fixed File Size Display**: Files now show correct sizes instead of 0 bytes
+- **Unified File Property Access**: Standardized to use `file_name` and `file_size` (with underscores) across all components
+- **Improved Null Handling**: Added comprehensive null checks to prevent `fileName.split()` runtime errors
+- **API Response Flexibility**: Components now handle both array and object response formats from file APIs
 
 ### 📁 Enhanced File Repository System
 - **Hierarchical Folder Structure**: Create and manage nested folders for better file organization
@@ -319,7 +373,7 @@ Optimized for Vercel:
 - **Selective File Presentation**: Attach specific files to upload applets for client viewing
 - **Storage Configuration**: Properly configured Supabase storage bucket with public access and RLS policies
 - **Multiple Navigation**: Breadcrumb navigation, folder clicks, and parent folder drops
-- **File Upload Applet Integration**: Restored ability to select specific files for presentation
+- **File Upload Applet Integration**: Working ability to select and attach specific files for presentation
 
 ### 🔒 Authentication & User Management System
 - **Controlled User Access**: Removed open signup - all users must be provisioned by admins

--- a/app/api/aloa-applets/[appletId]/route.js
+++ b/app/api/aloa-applets/[appletId]/route.js
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+// Create Supabase client for server-side operations
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+// PATCH - Update applet config
+export async function PATCH(request, { params }) {
+  try {
+    const { appletId } = params;
+    const body = await request.json();
+
+    console.log('=== PATCH REQUEST RECEIVED ===');
+    console.log('Applet ID:', appletId);
+    console.log('Config to save:', JSON.stringify(body.config, null, 2));
+
+    // First, check if the applet exists
+    const { data: existingApplet, error: fetchError } = await supabase
+      .from('aloa_applets')
+      .select('*')
+      .eq('id', appletId)
+      .single();
+
+    if (fetchError) {
+      console.error('Error fetching applet:', fetchError);
+      return NextResponse.json({ error: 'Applet not found', details: fetchError }, { status: 404 });
+    }
+
+    console.log('Existing applet found:', existingApplet.id);
+    console.log('Current config:', existingApplet.config);
+
+    // Update the applet
+    const { data: applet, error } = await supabase
+      .from('aloa_applets')
+      .update({
+        config: body.config,
+        updated_at: new Date().toISOString()
+      })
+      .eq('id', appletId)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error updating applet:', error);
+      return NextResponse.json({ error: 'Failed to update applet', details: error }, { status: 500 });
+    }
+
+    console.log('Update successful! New config:', applet.config);
+    return NextResponse.json({ applet, success: true });
+  } catch (error) {
+    console.error('Error in applet update:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+// GET - Fetch single applet
+export async function GET(request, { params }) {
+  try {
+    const { appletId } = params;
+
+    const { data: applet, error } = await supabase
+      .from('aloa_applets')
+      .select('*')
+      .eq('id', appletId)
+      .single();
+
+    if (error) {
+      console.error('Error fetching applet:', error);
+      return NextResponse.json({ error: 'Failed to fetch applet' }, { status: 500 });
+    }
+
+    return NextResponse.json({ applet });
+  } catch (error) {
+    console.error('Error in applet fetch:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+// DELETE - Delete applet
+export async function DELETE(request, { params }) {
+  try {
+    const { appletId } = params;
+
+    const { error } = await supabase
+      .from('aloa_applets')
+      .delete()
+      .eq('id', appletId);
+
+    if (error) {
+      console.error('Error deleting applet:', error);
+      return NextResponse.json({ error: 'Failed to delete applet' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error in applet deletion:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/aloa-projects/[projectId]/applet-interactions/route.js
+++ b/app/api/aloa-projects/[projectId]/applet-interactions/route.js
@@ -42,7 +42,7 @@ export async function GET(request, { params }) {
       }
     }
 
-    const { data, error } = await query.single();
+    const { data, error } = await query;
 
     if (error && error.code !== 'PGRST116') { // PGRST116 is "no rows returned"
       console.error('Error fetching interaction:', error);
@@ -51,7 +51,8 @@ export async function GET(request, { params }) {
 
     console.log('Found interaction data:', data);
 
-    return NextResponse.json(data || null);
+    // Return in the format expected by the frontend
+    return NextResponse.json({ interactions: data || [] });
   } catch (error) {
     console.error('Error in applet-interactions GET:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/components/SitemapBuilder.js
+++ b/components/SitemapBuilder.js
@@ -1,0 +1,729 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Map, Plus, X, ChevronRight, ChevronDown, Edit2, Trash2, Check, Home, Info, Users, Phone, ShoppingBag, FileText, Settings, Mail, Search, Menu } from 'lucide-react';
+
+const SitemapBuilder = ({
+  config = {},
+  projectScope = { main_pages: 5, aux_pages: 5 },
+  isLocked = false,
+  initialData = null,
+  onSave = () => {},
+  onAutoSave = () => {},
+  appletId = null,
+  projectId = null,
+  userId = null,
+  websiteUrl = null
+}) => {
+  // Common page templates with type and location hints
+  const mainPageTemplates = [
+    { name: 'About', icon: Info, description: 'About us/company info', type: 'main', location: 'nav' },
+    { name: 'Services', icon: Settings, description: 'Products or services', type: 'main', location: 'nav' },
+    { name: 'Solutions', icon: FileText, description: 'How you solve problems', type: 'main', location: 'nav' },
+    { name: 'Case Studies', icon: FileText, description: 'Success stories', type: 'main', location: 'nav' },
+    { name: 'Resources', icon: FileText, description: 'Guides, tools, content', type: 'main', location: 'nav' },
+    { name: 'Blog', icon: FileText, description: 'News and insights', type: 'main', location: 'nav' },
+    { name: 'Team', icon: Users, description: 'Meet the team', type: 'main', location: 'nav' },
+    { name: 'Pricing', icon: FileText, description: 'Plans and pricing', type: 'main', location: 'nav' },
+  ];
+
+  const auxiliaryPageTemplates = [
+    { name: 'Contact', icon: Phone, description: 'Contact information', type: 'aux', location: 'nav' },
+    { name: 'Privacy Policy', icon: FileText, description: 'Privacy policy', type: 'aux', location: 'footer' },
+    { name: 'Terms & Conditions', icon: FileText, description: 'Terms of service', type: 'aux', location: 'footer' },
+    { name: 'FAQ', icon: Search, description: 'Frequently asked questions', type: 'aux', location: 'footer' },
+    { name: 'Sitemap', icon: Map, description: 'Site structure', type: 'aux', location: 'footer' },
+    { name: 'Careers', icon: Users, description: 'Job opportunities', type: 'aux', location: 'footer' },
+    { name: 'Support', icon: Settings, description: 'Customer support', type: 'aux', location: 'footer' },
+  ];
+
+  const [sitemap, setSitemap] = useState(() => {
+    if (initialData) {
+      // Update the root name with website URL if available
+      return {
+        ...initialData,
+        name: websiteUrl || initialData.name || 'Website'
+      };
+    }
+    return {
+      name: websiteUrl || 'Website',
+      type: 'root',
+      children: [
+        { id: '1', name: 'Home', type: 'main', children: [] }
+      ]
+    };
+  });
+
+  const [selectedNode, setSelectedNode] = useState(null);
+  const [editingNode, setEditingNode] = useState(null);
+  const [editName, setEditName] = useState('');
+  const [expandedNodes, setExpandedNodes] = useState(new Set(['root']));
+  const [pageCount, setPageCount] = useState({ main: 1, aux: 0 });
+  const [lastSaved, setLastSaved] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [draggedNode, setDraggedNode] = useState(null);
+  const [dropTarget, setDropTarget] = useState(null);
+  const [dropPosition, setDropPosition] = useState(null); // 'before', 'after', or 'inside'
+
+  // Update root name when websiteUrl changes
+  useEffect(() => {
+    if (websiteUrl) {
+      setSitemap(prev => ({
+        ...prev,
+        name: websiteUrl
+      }));
+    }
+  }, [websiteUrl]);
+
+  // Auto-save functionality
+  const autoSave = useCallback(async (data) => {
+    if (isLocked || !onAutoSave) return;
+
+    setIsSaving(true);
+    try {
+      await onAutoSave(data);
+      setLastSaved(new Date());
+    } catch (error) {
+      console.error('Auto-save failed:', error);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [isLocked, onAutoSave]);
+
+  // Debounced auto-save
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (sitemap && sitemap !== initialData) {
+        autoSave(sitemap);
+      }
+    }, 2000); // Auto-save after 2 seconds of no changes
+
+    return () => clearTimeout(timer);
+  }, [sitemap, autoSave, initialData]);
+
+  useEffect(() => {
+    // Count pages whenever sitemap changes
+    const countPages = (node) => {
+      let main = 0;
+      let aux = 0;
+
+      const traverse = (n) => {
+        if (n.type === 'main') {
+          main++;
+        } else if (n.type === 'aux') {
+          aux++;
+        }
+
+        if (n.children) {
+          n.children.forEach(child => traverse(child));
+        }
+      };
+
+      if (sitemap.children) {
+        sitemap.children.forEach(child => traverse(child));
+      }
+
+      return { main, aux };
+    };
+
+    setPageCount(countPages(sitemap));
+  }, [sitemap]);
+
+  const toggleExpand = (nodeId) => {
+    const newExpanded = new Set(expandedNodes);
+    if (newExpanded.has(nodeId)) {
+      newExpanded.delete(nodeId);
+    } else {
+      newExpanded.add(nodeId);
+    }
+    setExpandedNodes(newExpanded);
+  };
+
+  const addPage = (parentNode, template = null) => {
+    if (isLocked) return;
+
+    const mainPagesLeft = projectScope.main_pages - pageCount.main;
+    const auxPagesLeft = projectScope.aux_pages - pageCount.aux;
+
+    // Determine page type based on template or availability
+    let pageType = 'main';
+    if (template?.type === 'aux') {
+      pageType = 'aux';
+      if (auxPagesLeft <= 0) {
+        alert('You have reached the maximum number of auxiliary pages in your plan.');
+        return;
+      }
+    } else if (template?.type === 'main' || !template) {
+      pageType = 'main';
+      if (mainPagesLeft <= 0) {
+        // If no main pages left but aux pages available, suggest aux
+        if (auxPagesLeft > 0) {
+          pageType = 'aux';
+        } else {
+          alert('You have reached the maximum number of pages in your plan.');
+          return;
+        }
+      }
+    }
+
+    const newPage = {
+      id: Date.now().toString(),
+      name: template?.name || 'New Page',
+      type: pageType,
+      location: template?.location || (pageType === 'aux' && ['Privacy Policy', 'Terms & Conditions', 'FAQ', 'Sitemap', 'Careers', 'Support'].includes(template?.name) ? 'footer' : 'nav'),
+      children: []
+    };
+
+    const updateNode = (node) => {
+      if (node === parentNode) {
+        return { ...node, children: [...(node.children || []), newPage] };
+      }
+      if (node.children) {
+        return { ...node, children: node.children.map(updateNode) };
+      }
+      return node;
+    };
+
+    setSitemap(updateNode(sitemap));
+    setExpandedNodes(new Set([...expandedNodes, parentNode.id || 'root']));
+  };
+
+  const deletePage = (targetNode) => {
+    if (isLocked || targetNode.id === '1' || targetNode.name === 'Home') return;
+
+    const deleteNode = (node) => {
+      if (node.children) {
+        return {
+          ...node,
+          children: node.children.filter(child => child.id !== targetNode.id).map(deleteNode)
+        };
+      }
+      return node;
+    };
+
+    setSitemap(deleteNode(sitemap));
+    setSelectedNode(null);
+  };
+
+  const startEdit = (node) => {
+    if (isLocked || node.type === 'root' || node.id === '1') return;
+    setEditingNode(node);
+    setEditName(node.name);
+  };
+
+  const saveEdit = () => {
+    if (!editingNode || isLocked) return;
+
+    const updateNodeName = (node) => {
+      if (node.id === editingNode.id) {
+        return { ...node, name: editName };
+      }
+      if (node.children) {
+        return { ...node, children: node.children.map(updateNodeName) };
+      }
+      return node;
+    };
+
+    setSitemap(updateNodeName(sitemap));
+    setEditingNode(null);
+    setEditName('');
+  };
+
+  const handleSave = () => {
+    console.log('handleSave called, isLocked:', isLocked);
+    console.log('onSave function:', onSave);
+    console.log('sitemap data:', sitemap);
+    if (isLocked) return;
+    onSave(sitemap);
+  };
+
+  const removeNodeFromTree = (tree, nodeId) => {
+    if (tree.children) {
+      tree.children = tree.children.filter(child => child.id !== nodeId);
+      tree.children.forEach(child => removeNodeFromTree(child, nodeId));
+    }
+    return tree;
+  };
+
+  const findNodeById = (tree, nodeId) => {
+    if (tree.id === nodeId) return tree;
+    if (tree.children) {
+      for (let child of tree.children) {
+        const found = findNodeById(child, nodeId);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+
+  const handleDrop = (e, targetNode, position) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (!draggedNode || draggedNode.id === targetNode.id) {
+      setDropTarget(null);
+      setDropPosition(null);
+      return;
+    }
+
+    // Don't allow dropping a parent into its own child
+    const isDescendant = (parent, childId) => {
+      if (parent.id === childId) return true;
+      if (parent.children) {
+        return parent.children.some(child => isDescendant(child, childId));
+      }
+      return false;
+    };
+
+    if (isDescendant(draggedNode, targetNode.id)) {
+      setDropTarget(null);
+      setDropPosition(null);
+      return;
+    }
+
+    const newSitemap = JSON.parse(JSON.stringify(sitemap));
+    const nodeToMove = findNodeById(newSitemap, draggedNode.id);
+
+    // Remove node from its current position
+    removeNodeFromTree(newSitemap, draggedNode.id);
+
+    // Add node to new position
+    if (position === 'inside') {
+      // Drop inside - make it a child
+      const target = findNodeById(newSitemap, targetNode.id || 'root');
+      if (!target.children) target.children = [];
+      target.children.push(nodeToMove);
+      setExpandedNodes(prev => new Set([...prev, targetNode.id || 'root']));
+    } else {
+      // Drop before or after - sibling placement
+      const parent = findParentOfNode(newSitemap, targetNode.id);
+      if (parent) {
+        const targetIndex = parent.children.findIndex(child => child.id === targetNode.id);
+        if (position === 'before') {
+          parent.children.splice(targetIndex, 0, nodeToMove);
+        } else {
+          parent.children.splice(targetIndex + 1, 0, nodeToMove);
+        }
+      }
+    }
+
+    setSitemap(newSitemap);
+    setDropTarget(null);
+    setDropPosition(null);
+  };
+
+  const findParentOfNode = (tree, nodeId, parent = null) => {
+    if (tree.children) {
+      for (let child of tree.children) {
+        if (child.id === nodeId) return tree;
+        const found = findParentOfNode(child, nodeId, tree);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+
+  const renderNode = (node, depth = 0) => {
+    const isExpanded = expandedNodes.has(node.id || 'root');
+    const hasChildren = node.children && node.children.length > 0;
+    const isRoot = node.type === 'root';
+    const isHome = node.id === '1' || node.name === 'Home'; // Home page is special
+    const isDragging = draggedNode?.id === node.id;
+
+    return (
+      <div key={node.id || 'root'} className={`${depth > 0 ? 'ml-6' : ''}`}>
+        {/* Drop zone - before */}
+        {!isRoot && !isHome && (
+          <div
+            className={`h-2 -mt-1 mb-1 rounded transition-all ${
+              dropTarget?.id === node.id && dropPosition === 'before'
+                ? 'bg-blue-400 opacity-50'
+                : draggedNode && !isDragging ? 'hover:bg-gray-200' : ''
+            }`}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDropTarget(node);
+              setDropPosition('before');
+            }}
+            onDragLeave={() => {
+              if (dropTarget?.id === node.id && dropPosition === 'before') {
+                setDropTarget(null);
+                setDropPosition(null);
+              }
+            }}
+            onDrop={(e) => handleDrop(e, node, 'before')}
+          />
+        )}
+
+        <div
+          className={`flex items-center gap-2 p-2 rounded-lg hover:bg-gray-100 ${
+            !isRoot && !isHome ? 'cursor-move' : 'cursor-pointer'
+          } ${
+            isDragging ? 'opacity-50' : ''
+          } ${
+            selectedNode?.id === node.id ? 'bg-purple-50 border border-purple-300' : ''
+          } ${
+            dropTarget?.id === node.id && dropPosition === 'inside'
+              ? 'ring-2 ring-blue-400 bg-blue-50'
+              : ''
+          }`}
+          onClick={() => {
+            if (!isRoot && !editingNode) {
+              setSelectedNode(node);
+            }
+          }}
+          draggable={!isRoot && !isHome && !isLocked && !editingNode}
+          onDragStart={(e) => {
+            if (isRoot || isHome || isLocked || editingNode) return;
+            e.stopPropagation();
+            setDraggedNode(node);
+          }}
+          onDragEnd={() => {
+            setDraggedNode(null);
+            setDropTarget(null);
+            setDropPosition(null);
+          }}
+          onDragOver={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!isRoot && draggedNode && draggedNode.id !== node.id) {
+              setDropTarget(node);
+              setDropPosition('inside');
+            }
+          }}
+          onDragLeave={(e) => {
+            e.stopPropagation();
+            if (dropTarget?.id === node.id && dropPosition === 'inside') {
+              setDropTarget(null);
+              setDropPosition(null);
+            }
+          }}
+          onDrop={(e) => {
+            if (!isRoot) {
+              handleDrop(e, node, 'inside');
+            }
+          }}
+        >
+          {hasChildren && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleExpand(node.id || 'root');
+              }}
+              className="p-1"
+            >
+              {isExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+            </button>
+          )}
+          {!hasChildren && <div className="w-6" />}
+
+          {/* Drag handle for non-root and non-home nodes */}
+          {!isRoot && !isHome && !isLocked && (
+            <div className="opacity-0 group-hover:opacity-100 transition-opacity cursor-move">
+              <svg className="w-4 h-4 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M7 2a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 14a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 2a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 14a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"/>
+              </svg>
+            </div>
+          )}
+
+          {isRoot ? (
+            <Home className="w-4 h-4 text-purple-600" />
+          ) : isHome ? (
+            <Home className="w-4 h-4 text-blue-600" />
+          ) : (
+            <FileText className={`w-4 h-4 ${node.type === 'main' ? 'text-blue-600' : 'text-gray-500'}`} />
+          )}
+
+          {editingNode?.id === node.id && !isRoot ? (
+            <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+              <input
+                type="text"
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    saveEdit();
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    setEditingNode(null);
+                    setEditName('');
+                  }
+                }}
+                className="px-2 py-1 border rounded"
+                autoFocus
+              />
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  saveEdit();
+                }}
+                className="text-green-600 hover:text-green-700"
+                type="button"
+              >
+                <Check className="w-4 h-4" />
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setEditingNode(null);
+                  setEditName('');
+                }}
+                className="text-gray-600 hover:text-gray-700"
+                type="button"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+          ) : (
+            <>
+              <span className={`${isRoot ? 'font-bold' : ''} ${isHome ? 'font-medium' : ''}`}>
+                {node.name}
+                {isHome && <span className="text-xs text-gray-500 ml-1">(Required)</span>}
+              </span>
+              {node.type === 'main' && <span className="text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded">Main</span>}
+              {node.type === 'aux' && <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">Auxiliary</span>}
+              {node.location === 'nav' && !isRoot && !isHome && (
+                <span className="text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded ml-1" title="Appears in main navigation">
+                  📍 Nav
+                </span>
+              )}
+              {node.location === 'footer' && (
+                <span className="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded ml-1" title="Appears in footer">
+                  📍 Footer
+                </span>
+              )}
+            </>
+          )}
+
+          {!isRoot && !isHome && !isLocked && (!editingNode || editingNode.id !== node.id) && (
+            <div className="ml-auto flex items-center gap-1 opacity-0 group-hover:opacity-100">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  startEdit(node);
+                }}
+                className="p-1 text-gray-600 hover:text-blue-600"
+              >
+                <Edit2 className="w-3 h-3" />
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  deletePage(node);
+                }}
+                className="p-1 text-gray-600 hover:text-red-600"
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Drop zone - after (for all non-root items) */}
+        {!isRoot && (
+          <div
+            className={`h-2 -mb-1 mt-1 rounded transition-all ${
+              dropTarget?.id === node.id && dropPosition === 'after'
+                ? 'bg-blue-400 opacity-50'
+                : draggedNode && !isDragging ? 'hover:bg-gray-200' : ''
+            }`}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setDropTarget(node);
+              setDropPosition('after');
+            }}
+            onDragLeave={() => {
+              if (dropTarget?.id === node.id && dropPosition === 'after') {
+                setDropTarget(null);
+                setDropPosition(null);
+              }
+            }}
+            onDrop={(e) => handleDrop(e, node, 'after')}
+          />
+        )}
+
+        {isExpanded && hasChildren && (
+          <div className="mt-1">
+            {node.children.map(child => renderNode(child, depth + 1))}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm">
+      <div className="p-6 border-b">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <Map className="w-5 h-5 text-purple-600" />
+            <h3 className="text-lg font-semibold">Sitemap Builder</h3>
+            {isSaving && (
+              <span className="text-sm text-gray-500 italic">Saving...</span>
+            )}
+            {!isSaving && lastSaved && (
+              <span className="text-sm text-gray-500">
+                Auto-saved {lastSaved.toLocaleTimeString()}
+              </span>
+            )}
+          </div>
+          {!isLocked && (
+            <button
+              onClick={handleSave}
+              className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+            >
+              Complete & Save
+            </button>
+          )}
+        </div>
+
+        {config.instructions && (
+          <div className="space-y-2 mb-4">
+            <p className="text-sm text-gray-600">{config.instructions}</p>
+            <p className="text-sm text-gray-500 italic">
+              You can edit the name of any page by clicking the pencil icon. The pages on the right are templates/example pages only.
+            </p>
+          </div>
+        )}
+
+        <div className="flex gap-4 text-sm">
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 bg-blue-600 rounded"></div>
+            <span>Main Pages: {pageCount.main}/{projectScope.main_pages}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-3 h-3 bg-gray-500 rounded"></div>
+            <span>Auxiliary Pages: {pageCount.aux}/{projectScope.aux_pages}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Sitemap Tree */}
+          <div className="lg:col-span-2">
+            <div className="border rounded-lg p-4 min-h-[400px]">
+              <div className="group">
+                {renderNode(sitemap)}
+              </div>
+
+              {!isLocked && (
+                <div className="mt-4 space-y-2">
+                  <button
+                    onClick={() => addPage(selectedNode || sitemap, { type: 'main', name: 'New Page' })}
+                    className="flex items-center gap-2 text-blue-600 hover:text-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={pageCount.main >= projectScope.main_pages}
+                  >
+                    <Plus className="w-4 h-4" />
+                    + Add Main Page {selectedNode && selectedNode.type !== 'root' ? `to ${selectedNode.name}` : ''}
+                  </button>
+                  <button
+                    onClick={() => addPage(selectedNode || sitemap, { type: 'aux', name: 'New Auxiliary Page' })}
+                    className="flex items-center gap-2 text-gray-600 hover:text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={pageCount.aux >= projectScope.aux_pages}
+                  >
+                    <Plus className="w-4 h-4" />
+                    + Add Auxiliary Page {selectedNode && selectedNode.type !== 'root' ? `to ${selectedNode.name}` : ''}
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Page Templates */}
+          {!isLocked && (
+            <div className="space-y-4">
+              {/* Main Pages Section */}
+              <div>
+                <h4 className="font-medium mb-2 text-blue-900">Main Pages</h4>
+                <p className="text-xs text-gray-500 mb-3">Core content pages for your website</p>
+                <div className="space-y-2">
+                  {mainPageTemplates.map((template) => {
+                    const Icon = template.icon;
+                    const disabled = pageCount.main >= projectScope.main_pages;
+                    return (
+                      <button
+                        key={template.name}
+                        onClick={() => addPage(selectedNode || sitemap, template)}
+                        className={`w-full flex items-center gap-3 p-2 border rounded-lg text-left transition-colors ${
+                          disabled ? 'opacity-50 cursor-not-allowed bg-gray-50' : 'hover:bg-blue-50 hover:border-blue-300'
+                        }`}
+                        disabled={disabled}
+                      >
+                        <Icon className="w-4 h-4 text-blue-600" />
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-medium">{template.name}</p>
+                            {template.location === 'nav' && (
+                              <span className="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded">
+                                Nav
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-xs text-gray-500">{template.description}</p>
+                        </div>
+                        {!disabled && <Plus className="w-4 h-4 text-blue-400" />}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Auxiliary Pages Section */}
+              <div>
+                <h4 className="font-medium mb-2 text-gray-700">Auxiliary Pages</h4>
+                <p className="text-xs text-gray-500 mb-3">Supporting pages (legal, contact, etc.)</p>
+                <div className="space-y-2">
+                  {auxiliaryPageTemplates.map((template) => {
+                    const Icon = template.icon;
+                    const disabled = pageCount.aux >= projectScope.aux_pages;
+                    return (
+                      <button
+                        key={template.name}
+                        onClick={() => addPage(selectedNode || sitemap, template)}
+                        className={`w-full flex items-center gap-3 p-2 border rounded-lg text-left transition-colors ${
+                          disabled ? 'opacity-50 cursor-not-allowed bg-gray-50' : 'hover:bg-gray-50'
+                        }`}
+                        disabled={disabled}
+                      >
+                        <Icon className="w-4 h-4 text-gray-600" />
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-medium">{template.name}</p>
+                            {template.location === 'nav' && (
+                              <span className="text-xs bg-green-100 text-green-700 px-1.5 py-0.5 rounded">
+                                Nav
+                              </span>
+                            )}
+                            {template.location === 'footer' && (
+                              <span className="text-xs bg-purple-100 text-purple-700 px-1.5 py-0.5 rounded">
+                                Footer
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-xs text-gray-500">{template.description}</p>
+                        </div>
+                        {!disabled && <Plus className="w-4 h-4 text-gray-400" />}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {isLocked && (
+          <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+            <p className="text-sm text-yellow-800">
+              This sitemap is locked and cannot be edited at this time.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SitemapBuilder;

--- a/components/SitemapBuilderV2.js
+++ b/components/SitemapBuilderV2.js
@@ -1,0 +1,619 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { Map, Plus, X, ChevronRight, ChevronDown, Edit2, Trash2, Check, Home, Info, Users, Phone, ShoppingBag, FileText, Settings, Mail, Search, Menu, Navigation, Link } from 'lucide-react';
+
+const SitemapBuilderV2 = ({
+  config = {},
+  projectScope = { main_pages: 5, aux_pages: 5 },
+  isLocked = false,
+  initialData = null,
+  onSave = () => {},
+  onAutoSave = () => {},
+  appletId = null,
+  projectId = null,
+  userId = null,
+  websiteUrl = null
+}) => {
+  // Common page templates
+  const pageTemplates = [
+    { name: 'About', icon: Info, description: 'About us/company info', type: 'main' },
+    { name: 'Services', icon: Settings, description: 'Products or services', type: 'main' },
+    { name: 'Solutions', icon: FileText, description: 'How you solve problems', type: 'main' },
+    { name: 'Case Studies', icon: FileText, description: 'Success stories', type: 'main' },
+    { name: 'Resources', icon: FileText, description: 'Guides, tools, content', type: 'main' },
+    { name: 'Blog', icon: FileText, description: 'News and insights', type: 'main' },
+    { name: 'Team', icon: Users, description: 'Meet the team', type: 'main' },
+    { name: 'Pricing', icon: FileText, description: 'Plans and pricing', type: 'main' },
+    { name: 'Contact', icon: Phone, description: 'Contact information', type: 'aux' },
+    { name: 'Privacy Policy', icon: FileText, description: 'Privacy policy', type: 'aux' },
+    { name: 'Terms & Conditions', icon: FileText, description: 'Terms of service', type: 'aux' },
+    { name: 'FAQ', icon: Search, description: 'Frequently asked questions', type: 'aux' },
+    { name: 'Sitemap', icon: Map, description: 'Site structure', type: 'aux' },
+    { name: 'Careers', icon: Users, description: 'Job opportunities', type: 'aux' },
+    { name: 'Support', icon: Settings, description: 'Customer support', type: 'aux' },
+  ];
+
+  // Initialize sitemap with navigation and footer sections
+  const [sitemap, setSitemap] = useState(() => {
+    console.log('Initializing sitemap with data:', initialData);
+
+    if (initialData) {
+      // Handle old format (with children) and new format (with navigation/footer)
+      if (initialData.navigation || initialData.footer) {
+        console.log('Loading saved sitemap data:', initialData);
+        return {
+          ...initialData,
+          name: websiteUrl || initialData.name || 'Website'
+        };
+      } else if (initialData.children) {
+        // Convert old format to new format
+        console.log('Converting old format to new format');
+        const navPages = [];
+        const footerPages = [];
+
+        initialData.children.forEach(page => {
+          if (page.location === 'footer' || ['Privacy Policy', 'Terms & Conditions', 'FAQ', 'Sitemap', 'Careers', 'Support'].includes(page.name)) {
+            footerPages.push(page);
+          } else {
+            navPages.push(page);
+          }
+        });
+
+        return {
+          name: websiteUrl || initialData.name || 'Website',
+          navigation: navPages,
+          footer: footerPages
+        };
+      }
+    }
+
+    console.log('No initial data, creating default sitemap');
+    return {
+      name: websiteUrl || 'Website',
+      navigation: [
+        { id: '1', name: 'Home', type: 'main', children: [] }
+      ],
+      footer: []
+    };
+  });
+
+  const [draggedItem, setDraggedItem] = useState(null);
+  const [dragOverSection, setDragOverSection] = useState(null);
+  const [dragOverIndex, setDragOverIndex] = useState(null);
+  const [pageCount, setPageCount] = useState({ main: 1, aux: 0 });
+  const [lastSaved, setLastSaved] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [editingPage, setEditingPage] = useState(null);
+  const [editName, setEditName] = useState('');
+  const [isDragging, setIsDragging] = useState(false);
+  const justDraggedRef = useRef(false);
+  const isProcessingDrop = useRef(false);
+
+  // Count pages
+  useEffect(() => {
+    const countPages = (pages) => {
+      let main = 0;
+      let aux = 0;
+
+      pages.forEach(page => {
+        if (page.type === 'main') main++;
+        else if (page.type === 'aux') aux++;
+        if (page.children) {
+          const childCounts = countPages(page.children);
+          main += childCounts.main;
+          aux += childCounts.aux;
+        }
+      });
+
+      return { main, aux };
+    };
+
+    const allPages = [...(sitemap.navigation || []), ...(sitemap.footer || [])];
+    const counts = countPages(allPages);
+    setPageCount(counts);
+  }, [sitemap]);
+
+  // Auto-save with debounce
+  useEffect(() => {
+    if (!onAutoSave || isLocked) return;
+
+    // Don't save on initial mount
+    if (sitemap === initialData) return;
+
+    console.log('Auto-save triggered, sitemap changed:', sitemap);
+
+    const timer = setTimeout(() => {
+      console.log('Auto-saving sitemap...');
+      setIsSaving(true);
+
+      // Call onAutoSave and handle any errors
+      try {
+        onAutoSave(sitemap);
+        setLastSaved(new Date());
+        console.log('Auto-save successful');
+      } catch (error) {
+        console.error('Auto-save failed:', error);
+      }
+
+      setTimeout(() => setIsSaving(false), 1000);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, [sitemap, onAutoSave, isLocked]);
+
+  const handleDragStart = (e, item, fromSection) => {
+    // Prevent dragging Home page
+    if (isLocked || (item.name === 'Home' || item.id === '1')) return;
+    setDraggedItem({ ...item, fromSection });
+    setIsDragging(true);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e, section, index = null) => {
+    e.preventDefault();
+    if (!draggedItem || isLocked) return;
+
+    // Don't show drop indicator above Home in navigation
+    if (section === 'navigation' && index === 0) {
+      return;
+    }
+
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverSection(section);
+    setDragOverIndex(index);
+  };
+
+  const handleDrop = (e, toSection, toIndex = null) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Prevent duplicate processing
+    if (isProcessingDrop.current) return;
+    if (!draggedItem || isLocked) return;
+
+    isProcessingDrop.current = true;
+
+    // Prevent dropping above Home in navigation
+    if (toSection === 'navigation' && toIndex === 0) {
+      setDraggedItem(null);
+      setDragOverSection(null);
+      setDragOverIndex(null);
+      isProcessingDrop.current = false;
+      return;
+    }
+
+    const newSitemap = { ...sitemap };
+
+    // If dragging from templates, create a new page
+    if (draggedItem.fromSection === 'templates') {
+      // Create more unique ID to prevent duplicates
+      const newPage = {
+        id: `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        name: draggedItem.name,
+        type: draggedItem.type,
+        children: []
+      };
+
+      // Check if we have room for this page type
+      const isMain = draggedItem.type === 'main';
+      const limit = isMain ? projectScope.main_pages : projectScope.aux_pages;
+      const current = isMain ? pageCount.main : pageCount.aux;
+
+      if (current >= limit) {
+        alert(`You have reached the maximum number of ${isMain ? 'main' : 'auxiliary'} pages in your plan.`);
+        setDraggedItem(null);
+        setDragOverSection(null);
+        setDragOverIndex(null);
+        return;
+      }
+
+      // Add to target section
+      const targetArray = toSection === 'navigation' ? newSitemap.navigation : newSitemap.footer;
+      if (toIndex !== null && toIndex !== undefined) {
+        targetArray.splice(toIndex, 0, newPage);
+      } else {
+        targetArray.push(newPage);
+      }
+    } else {
+      // Remove from original section (for existing pages)
+      if (draggedItem.fromSection === 'navigation') {
+        newSitemap.navigation = newSitemap.navigation.filter(item => item.id !== draggedItem.id);
+      } else {
+        newSitemap.footer = newSitemap.footer.filter(item => item.id !== draggedItem.id);
+      }
+
+      // Add to new section
+      const targetArray = toSection === 'navigation' ? newSitemap.navigation : newSitemap.footer;
+      if (toIndex !== null && toIndex !== undefined) {
+        targetArray.splice(toIndex, 0, draggedItem);
+      } else {
+        targetArray.push(draggedItem);
+      }
+    }
+
+    setSitemap(newSitemap);
+    setDraggedItem(null);
+    setDragOverSection(null);
+    setDragOverIndex(null);
+
+    // Reset processing flag after a delay
+    setTimeout(() => {
+      isProcessingDrop.current = false;
+    }, 100);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedItem(null);
+    setDragOverSection(null);
+    setDragOverIndex(null);
+    // Set flag to prevent click from firing
+    justDraggedRef.current = true;
+    setTimeout(() => {
+      setIsDragging(false);
+      justDraggedRef.current = false;
+    }, 200);
+  };
+
+  const addPage = (template, section) => {
+    if (isLocked) return;
+
+    const pageType = template.type || 'main';
+    const limit = pageType === 'main' ? projectScope.main_pages : projectScope.aux_pages;
+    const current = pageType === 'main' ? pageCount.main : pageCount.aux;
+
+    if (current >= limit) {
+      alert(`You have reached the maximum number of ${pageType === 'main' ? 'main' : 'auxiliary'} pages in your plan.`);
+      return;
+    }
+
+    const newPage = {
+      id: Date.now().toString(),
+      name: template.name,
+      type: pageType,
+      children: []
+    };
+
+    setSitemap(prev => ({
+      ...prev,
+      [section]: [...prev[section], newPage]
+    }));
+  };
+
+  const deletePage = (pageId, section) => {
+    // Only prevent deletion of Home page (id '1')
+    console.log('Attempting to delete page with ID:', pageId, 'Name:', sitemap[section].find(p => p.id === pageId)?.name);
+    if (isLocked || pageId === '1') {
+      console.log('Delete blocked - isLocked:', isLocked, 'pageId:', pageId);
+      return;
+    }
+
+    setSitemap(prev => ({
+      ...prev,
+      [section]: prev[section].filter(page => page.id !== pageId)
+    }));
+  };
+
+  const startEdit = (page, section) => {
+    // Prevent editing Home page
+    if (isLocked || page.name === 'Home' || page.id === '1') return;
+    setEditingPage({ ...page, section });
+    setEditName(page.name);
+  };
+
+  const saveEdit = () => {
+    if (!editingPage || !editName.trim()) return;
+
+    setSitemap(prev => ({
+      ...prev,
+      [editingPage.section]: prev[editingPage.section].map(page =>
+        page.id === editingPage.id ? { ...page, name: editName.trim() } : page
+      )
+    }));
+
+    setEditingPage(null);
+    setEditName('');
+  };
+
+  const cancelEdit = () => {
+    setEditingPage(null);
+    setEditName('');
+  };
+
+  const handleSave = () => {
+    if (isLocked) {
+      console.log('Cannot save - sitemap is locked');
+      return;
+    }
+
+    console.log('handleSave called');
+    console.log('Saving sitemap:', sitemap);
+    console.log('onSave function exists:', typeof onSave === 'function');
+
+    if (typeof onSave === 'function') {
+      onSave(sitemap);
+    } else {
+      console.error('onSave prop is not a function!');
+    }
+  };
+
+  const renderPage = (page, section, index) => {
+    const isHome = page.name === 'Home' || page.id === '1';
+
+    return (
+      <div
+        key={page.id}
+        draggable={!isLocked && !isHome}
+        onDragStart={(e) => handleDragStart(e, page, section)}
+        onDragOver={(e) => handleDragOver(e, section, index)}
+        onDrop={(e) => {
+          e.stopPropagation();
+          handleDrop(e, section, index);
+        }}
+        onDragEnd={handleDragEnd}
+        className={`
+          group flex items-center gap-2 p-2 rounded-lg border transition-all
+          ${isHome ? 'bg-blue-50 border-blue-200' : 'bg-white hover:bg-gray-50'}
+          ${draggedItem?.id === page.id ? 'opacity-50' : ''}
+          ${dragOverSection === section && dragOverIndex === index ? 'border-blue-400 bg-blue-50' : 'border-gray-200'}
+          ${!isLocked && !isHome ? 'cursor-move' : ''}
+        `}
+      >
+        {!isLocked && !isHome && (
+          <div className="opacity-50 hover:opacity-100">
+            <svg className="w-4 h-4 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M7 2a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 14a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM7 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 2a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 6a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 14a2 2 0 1 1-4 0 2 2 0 0 1 4 0zM17 18a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"/>
+            </svg>
+          </div>
+        )}
+
+        {isHome ? (
+          <Home className="w-4 h-4 text-blue-600" />
+        ) : (
+          <FileText className={`w-4 h-4 ${page.type === 'main' ? 'text-blue-600' : 'text-gray-500'}`} />
+        )}
+
+        {editingPage?.id === page.id ? (
+          <div className="flex-1 flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+            <input
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  saveEdit();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelEdit();
+                }
+              }}
+              className="px-2 py-1 border rounded text-sm flex-1"
+              autoFocus
+            />
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                saveEdit();
+              }}
+              className="text-green-600 hover:text-green-700 p-1"
+            >
+              <Check className="w-4 h-4" />
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                cancelEdit();
+              }}
+              className="text-gray-600 hover:text-gray-700 p-1"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        ) : (
+          <>
+            <span className={`flex-1 ${isHome ? 'font-medium' : ''}`}>
+              {page.name}
+              {isHome && <span className="text-xs text-gray-500 ml-1">(Required)</span>}
+            </span>
+
+            {!isLocked && !isHome && (
+              <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    startEdit(page, section);
+                  }}
+                  className="p-1 text-gray-600 hover:text-blue-600"
+                  title="Edit page name"
+                >
+                  <Edit2 className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    deletePage(page.id, section);
+                  }}
+                  className="p-1 text-gray-400 hover:text-red-600"
+                  title="Delete page"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            )}
+
+            {page.type === 'main' && (
+              <span className="text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded">Main</span>
+            )}
+            {page.type === 'aux' && (
+              <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded">Aux</span>
+            )}
+          </>
+        )}
+
+      </div>
+    );
+  };
+
+  const renderSection = (title, sectionKey, icon) => {
+    const pages = sitemap[sectionKey] || [];
+    const Icon = icon;
+
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Icon className="w-5 h-5 text-gray-600" />
+          <h3 className="font-semibold text-gray-900">{title}</h3>
+          <span className="text-xs text-gray-500">({pages.length} pages)</span>
+        </div>
+
+        <div
+          onDragOver={(e) => handleDragOver(e, sectionKey)}
+          onDrop={(e) => {
+            e.stopPropagation();
+            handleDrop(e, sectionKey, pages.length);
+          }}
+          className={`
+            space-y-2 min-h-[100px] p-2 rounded border-2 border-dashed
+            ${dragOverSection === sectionKey && dragOverIndex === null ? 'border-blue-400 bg-blue-50' : 'border-gray-200'}
+          `}
+        >
+          {pages.length === 0 ? (
+            <p className="text-sm text-gray-400 text-center py-4">
+              Drag pages here or add from templates
+            </p>
+          ) : (
+            pages.map((page, index) => renderPage(page, sectionKey, index))
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex h-full">
+      {/* Main Content */}
+      <div className="flex-1 p-6 overflow-y-auto">
+        <div className="max-w-4xl mx-auto">
+          {/* Header */}
+          <div className="mb-6">
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-3">
+                <Map className="w-6 h-6 text-purple-600" />
+                <h2 className="text-2xl font-bold">{sitemap.name || 'Website'} Sitemap</h2>
+              </div>
+              {!isLocked && (
+                <button
+                  onClick={handleSave}
+                  className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+                >
+                  Complete & Save
+                </button>
+              )}
+            </div>
+
+            {/* Instructions */}
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 space-y-2">
+              <p className="text-sm text-blue-800">
+                Build your website's sitemap based on your project scope of <strong>{projectScope.main_pages} main pages</strong> and <strong>{projectScope.aux_pages} auxiliary pages</strong>.
+              </p>
+              <p className="text-sm text-blue-800">
+                <strong>Main pages</strong> are your core content pages (About, Services, Blog, etc.).
+                <strong>Auxiliary pages</strong> are supporting pages (Contact, Privacy Policy, FAQ, etc.).
+              </p>
+              <p className="text-sm text-blue-800">
+                Organize pages by dragging them between Main Navigation and Footer sections.
+                Pages in <strong>Main Navigation</strong> will appear in your site's primary menu, while <strong>Footer</strong> pages will be links at the bottom of your site.
+              </p>
+            </div>
+
+            {/* Page Count */}
+            <div className="flex gap-4 mt-3">
+              <div className="text-sm">
+                <span className="font-medium">Main Pages:</span> {pageCount.main} / {projectScope.main_pages}
+              </div>
+              <div className="text-sm">
+                <span className="font-medium">Auxiliary Pages:</span> {pageCount.aux} / {projectScope.aux_pages}
+              </div>
+            </div>
+          </div>
+
+          {/* Two Sections */}
+          <div className="space-y-6">
+            {renderSection('Main Navigation', 'navigation', Navigation)}
+            {renderSection('Footer Links', 'footer', Link)}
+          </div>
+
+          {/* Save Status */}
+          {lastSaved && (
+            <div className="mt-4 text-xs text-gray-500 text-center">
+              {isSaving ? 'Saving...' : `Auto-saved ${lastSaved.toLocaleTimeString()}`}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Sidebar with Templates */}
+      {!isLocked && (
+        <div className="w-80 border-l bg-gray-50 p-4 overflow-y-auto">
+          <h3 className="font-semibold text-gray-900 mb-4">Page Templates</h3>
+          <p className="text-xs text-gray-500 mb-4">
+            Drag templates to Main Navigation or Footer Links
+          </p>
+
+          <div className="space-y-2">
+            {pageTemplates.map((template) => {
+              const Icon = template.icon;
+              const isMain = template.type === 'main';
+              const disabled = isMain
+                ? pageCount.main >= projectScope.main_pages
+                : pageCount.aux >= projectScope.aux_pages;
+
+              return (
+                <div
+                  key={template.name}
+                  draggable={!disabled}
+                  onDragStart={(e) => {
+                    if (disabled) return;
+                    e.stopPropagation();
+                    const tempPage = {
+                      id: `template-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+                      name: template.name,
+                      type: template.type,
+                      children: [],
+                      isTemplate: true
+                    };
+                    handleDragStart(e, tempPage, 'templates');
+                  }}
+                  onDragEnd={handleDragEnd}
+                >
+                  <div
+                    className={`
+                      w-full flex items-center gap-3 p-2 border rounded-lg text-left transition-colors bg-white
+                      ${disabled ? 'opacity-50 cursor-not-allowed bg-gray-50' : 'hover:bg-blue-50 hover:border-blue-300 cursor-move'}
+                    `}
+                  >
+                    <Icon className={`w-4 h-4 ${isMain ? 'text-blue-600' : 'text-gray-600'}`} />
+                    <div className="flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium">{template.name}</p>
+                        {isMain ? (
+                          <span className="text-xs bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded">Main</span>
+                        ) : (
+                          <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">Aux</span>
+                        )}
+                      </div>
+                      <p className="text-xs text-gray-500">{template.description}</p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SitemapBuilderV2;

--- a/supabase/add_missing_applet_library_columns.sql
+++ b/supabase/add_missing_applet_library_columns.sql
@@ -1,0 +1,41 @@
+-- Add missing columns to aloa_applet_library table if they don't exist
+ALTER TABLE aloa_applet_library
+ADD COLUMN IF NOT EXISTS category TEXT;
+
+ALTER TABLE aloa_applet_library
+ADD COLUMN IF NOT EXISTS client_instructions TEXT;
+
+ALTER TABLE aloa_applet_library
+ADD COLUMN IF NOT EXISTS internal_notes TEXT;
+
+-- Now insert the sitemap applet
+INSERT INTO aloa_applet_library (
+  name,
+  description,
+  type,
+  icon,
+  default_config,
+  tags,
+  category,
+  is_active,
+  requires_approval,
+  client_instructions,
+  internal_notes
+) VALUES (
+  'Sitemap Builder',
+  'Interactive sitemap builder for planning website structure',
+  'sitemap',
+  'Map',
+  jsonb_build_object(
+    'locked', false,
+    'instructions', 'Build your website sitemap by organizing pages and their relationships. Drag and drop pages to create your ideal site structure.',
+    'allow_custom_pages', true,
+    'template', 'standard'
+  ),
+  ARRAY['planning', 'structure', 'navigation'],
+  'Planning',
+  true,
+  false,
+  'Create your website''s sitemap by organizing pages according to your project scope. You can drag and drop pages to arrange them hierarchically.',
+  'Client uses this to define their site structure based on the contracted number of pages.'
+) ON CONFLICT DO NOTHING;

--- a/supabase/add_project_metadata_fields.sql
+++ b/supabase/add_project_metadata_fields.sql
@@ -1,0 +1,90 @@
+-- Add structured metadata fields to aloa_projects
+-- This migration adds project_type and scope details to the metadata field
+
+-- Update the metadata field with default structure for existing projects
+UPDATE aloa_projects
+SET metadata = jsonb_set(
+  COALESCE(metadata, '{}'::jsonb),
+  '{project_type}',
+  '"Website Design"'::jsonb
+)
+WHERE metadata IS NULL OR metadata->>'project_type' IS NULL;
+
+-- Add scope information to metadata
+UPDATE aloa_projects
+SET metadata = jsonb_set(
+  COALESCE(metadata, '{}'::jsonb),
+  '{scope}',
+  '{
+    "main_pages": 5,
+    "aux_pages": 5,
+    "description": "Standard website package"
+  }'::jsonb
+)
+WHERE metadata IS NULL OR metadata->>'scope' IS NULL;
+
+-- Add additional project details structure
+UPDATE aloa_projects
+SET metadata = metadata || '{
+  "editable_fields": {
+    "project_type": "Website Design",
+    "scope": {
+      "main_pages": 5,
+      "aux_pages": 5,
+      "description": "Standard website package"
+    },
+    "budget_details": {
+      "design": 0,
+      "development": 0,
+      "content": 0,
+      "other": 0
+    },
+    "timeline_notes": "",
+    "special_requirements": "",
+    "target_audience": "",
+    "brand_guidelines": "",
+    "competitors": []
+  }
+}'::jsonb
+WHERE metadata->>'editable_fields' IS NULL;
+
+-- Create a function to ensure project metadata structure
+CREATE OR REPLACE FUNCTION ensure_project_metadata()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Ensure metadata has required structure
+  IF NEW.metadata IS NULL THEN
+    NEW.metadata = '{}'::jsonb;
+  END IF;
+
+  -- Ensure project_type exists
+  IF NEW.metadata->>'project_type' IS NULL THEN
+    NEW.metadata = jsonb_set(NEW.metadata, '{project_type}', '"Website Design"'::jsonb);
+  END IF;
+
+  -- Ensure scope exists
+  IF NEW.metadata->>'scope' IS NULL THEN
+    NEW.metadata = jsonb_set(NEW.metadata, '{scope}', '{
+      "main_pages": 5,
+      "aux_pages": 5,
+      "description": "Standard website package"
+    }'::jsonb);
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to ensure metadata structure on insert/update
+DROP TRIGGER IF EXISTS ensure_project_metadata_trigger ON aloa_projects;
+CREATE TRIGGER ensure_project_metadata_trigger
+BEFORE INSERT OR UPDATE ON aloa_projects
+FOR EACH ROW
+EXECUTE FUNCTION ensure_project_metadata();
+
+-- Add indexes for better query performance on metadata
+CREATE INDEX IF NOT EXISTS idx_aloa_projects_metadata_project_type
+ON aloa_projects ((metadata->>'project_type'));
+
+CREATE INDEX IF NOT EXISTS idx_aloa_projects_metadata_scope
+ON aloa_projects ((metadata->'scope'));

--- a/supabase/add_project_metadata_fields_fixed.sql
+++ b/supabase/add_project_metadata_fields_fixed.sql
@@ -1,0 +1,87 @@
+-- Add metadata column if it doesn't exist
+ALTER TABLE aloa_projects
+ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}';
+
+-- Also add a rules column for backward compatibility with existing code that uses project.rules
+ALTER TABLE aloa_projects
+ADD COLUMN IF NOT EXISTS rules JSONB DEFAULT '{}';
+
+-- Update existing projects to have default metadata structure
+UPDATE aloa_projects
+SET metadata = jsonb_build_object(
+  'project_type', COALESCE(metadata->>'project_type', 'Website Design'),
+  'scope', jsonb_build_object(
+    'main_pages', COALESCE((metadata->'scope'->>'main_pages')::int, (rules->>'main_pages')::int, 5),
+    'aux_pages', COALESCE((metadata->'scope'->>'aux_pages')::int, (rules->>'aux_pages')::int, 5),
+    'description', COALESCE(metadata->'scope'->>'description', 'Standard website package')
+  ),
+  'editable_fields', COALESCE(metadata->'editable_fields', jsonb_build_object(
+    'budget_details', jsonb_build_object(
+      'design', 0,
+      'development', 0,
+      'content', 0,
+      'other', 0
+    ),
+    'timeline_notes', '',
+    'special_requirements', '',
+    'target_audience', '',
+    'brand_guidelines', '',
+    'competitors', '[]'::jsonb
+  ))
+)
+WHERE metadata IS NULL OR metadata = '{}' OR metadata->>'project_type' IS NULL;
+
+-- Also populate rules for backward compatibility
+UPDATE aloa_projects
+SET rules = jsonb_build_object(
+  'main_pages', COALESCE((metadata->'scope'->>'main_pages')::int, (rules->>'main_pages')::int, 5),
+  'aux_pages', COALESCE((metadata->'scope'->>'aux_pages')::int, (rules->>'aux_pages')::int, 5)
+)
+WHERE rules IS NULL OR rules = '{}';
+
+-- Create a function to ensure project metadata structure
+CREATE OR REPLACE FUNCTION ensure_project_metadata()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Ensure metadata exists
+  IF NEW.metadata IS NULL THEN
+    NEW.metadata = '{}'::jsonb;
+  END IF;
+
+  -- Ensure project_type exists
+  IF NEW.metadata->>'project_type' IS NULL THEN
+    NEW.metadata = jsonb_set(NEW.metadata, '{project_type}', '"Website Design"'::jsonb);
+  END IF;
+
+  -- Ensure scope exists with default values
+  IF NEW.metadata->>'scope' IS NULL THEN
+    NEW.metadata = jsonb_set(NEW.metadata, '{scope}', jsonb_build_object(
+      'main_pages', 5,
+      'aux_pages', 5,
+      'description', 'Standard website package'
+    ));
+  END IF;
+
+  -- Sync rules for backward compatibility
+  NEW.rules = jsonb_build_object(
+    'main_pages', COALESCE((NEW.metadata->'scope'->>'main_pages')::int, 5),
+    'aux_pages', COALESCE((NEW.metadata->'scope'->>'aux_pages')::int, 5)
+  );
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to ensure metadata structure on insert/update
+DROP TRIGGER IF EXISTS ensure_project_metadata_trigger ON aloa_projects;
+CREATE TRIGGER ensure_project_metadata_trigger
+BEFORE INSERT OR UPDATE ON aloa_projects
+FOR EACH ROW
+EXECUTE FUNCTION ensure_project_metadata();
+
+-- Add indexes for better query performance on metadata
+CREATE INDEX IF NOT EXISTS idx_aloa_projects_metadata_project_type
+ON aloa_projects ((metadata->>'project_type'));
+
+CREATE INDEX IF NOT EXISTS idx_aloa_projects_metadata_scope
+ON aloa_projects ((metadata->'scope'));

--- a/supabase/add_sitemap_applet.sql
+++ b/supabase/add_sitemap_applet.sql
@@ -1,0 +1,18 @@
+-- Add sitemap applet type to the enum
+ALTER TYPE applet_type ADD VALUE IF NOT EXISTS 'sitemap';
+
+-- Insert sitemap applet type into applet_types table
+INSERT INTO aloa_applet_types (type, name, description, icon, default_config)
+VALUES (
+  'sitemap',
+  'Sitemap Builder',
+  'Interactive sitemap builder for planning website structure',
+  'sitemap',
+  '{
+    "locked": false,
+    "max_pages": 10,
+    "allow_custom_pages": true,
+    "template": "standard",
+    "instructions": "Build your website sitemap by organizing pages and their relationships"
+  }'::jsonb
+) ON CONFLICT (type) DO NOTHING;

--- a/supabase/add_sitemap_applet_simple.sql
+++ b/supabase/add_sitemap_applet_simple.sql
@@ -1,0 +1,17 @@
+-- First check if applet_type enum exists and add sitemap value
+DO $$
+BEGIN
+    -- Check if the type exists
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        WHERE t.typname = 'applet_type' AND e.enumlabel = 'sitemap'
+    ) THEN
+        ALTER TYPE applet_type ADD VALUE IF NOT EXISTS 'sitemap';
+    END IF;
+END
+$$;
+
+-- The sitemap applet doesn't need an entry in a types table since the system
+-- appears to handle applet types through the enum and config in the applets themselves.
+-- The applet will be configured when added to a projectlet through the admin UI.

--- a/supabase/add_sitemap_to_library.sql
+++ b/supabase/add_sitemap_to_library.sql
@@ -1,0 +1,29 @@
+-- Add sitemap applet to the applet library
+INSERT INTO aloa_applet_library (
+  name,
+  description,
+  type,
+  icon,
+  default_config,
+  tags,
+  is_active,
+  requires_approval,
+  client_instructions,
+  internal_notes
+) VALUES (
+  'Sitemap Builder',
+  'Interactive sitemap builder for planning website structure',
+  'sitemap',
+  'Map',
+  jsonb_build_object(
+    'locked', false,
+    'instructions', 'Build your website sitemap by organizing pages and their relationships. Drag and drop pages to create your ideal site structure.',
+    'allow_custom_pages', true,
+    'template', 'standard'
+  ),
+  ARRAY['planning', 'structure', 'navigation'],
+  true,
+  false,
+  'Create your website''s sitemap by organizing pages according to your project scope. You can drag and drop pages to arrange them hierarchically.',
+  'Client uses this to define their site structure based on the contracted number of pages.'
+) ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- Fixed Complete & Save functionality for sitemap builder applets
- Implemented proper auto-save persistence with API state updates  
- Made sitemap completion avatars clickable to show submitted data following standard applet UI pattern

## Changes
- Created `/app/api/aloa-applets/[appletId]/route.js` API endpoint for updating applet configurations
- Fixed incorrect table references from `aloa_projectlet_applets` to `aloa_applets`
- Updated client-side completion tracking to properly persist state
- Made completion avatars clickable in the collapsed admin view (right side, next to trash icon)
- Added sitemap viewer modal to display submitted data when avatar is clicked
- Updated README to document standard applet behavior

## Test Plan
- [x] Complete a sitemap applet as a client user
- [x] Verify completion persists after page refresh  
- [x] Verify auto-save data persists after refresh
- [x] View completed applet from admin at `/admin/project/[projectId]`
- [x] Click completion avatar to view submitted sitemap data
- [x] Verify avatars appear in standard location (collapsed view, right side)

🤖 Generated with [Claude Code](https://claude.ai/code)