### PR TITLE
Simplify Password Reset with Auth Callback

### DIFF
--- a/app/auth/update-password/page.js
+++ b/app/auth/update-password/page.js
@@ -1,110 +1,8 @@
 'use client';
 
-import { useEffect, useState, Suspense } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import LoadingSpinner from '@/components/LoadingSpinner';
-import { createClient } from '@/lib/supabase-auth';
-
-function UpdatePasswordContent() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [status, setStatus] = useState('Preparing password reset…');
-
-  const queryKey = searchParams.toString();
-
-  useEffect(() => {
-    const handleRecovery = async () => {
-      try {
-        const supabase = createClient();
-        if (!supabase) {
-          setStatus('Unable to initialize authentication client.');
-          setTimeout(() => router.replace('/auth/reset-password?error=Authentication unavailable'), 1500);
-          return;
-        }
-
-        const hashParams = new URLSearchParams((typeof window !== 'undefined' && window.location.hash?.substring(1)) || '');
-        const queryCode = searchParams.get('code');
-        const queryToken = searchParams.get('token');
-        const accessToken = hashParams.get('access_token');
-        const refreshToken = hashParams.get('refresh_token');
-
-        if (!(accessToken && refreshToken) && !queryCode && !queryToken) {
-          const type = hashParams.get('type');
-          if (type !== 'recovery') {
-            router.replace('/auth/reset-password?error=Invalid or expired reset link');
-            return;
-          }
-        }
-
-        setStatus('Verifying reset link…');
-
-        let sessionTokens = null;
-
-        if (accessToken && refreshToken) {
-          const { error } = await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken });
-          if (error) {
-            throw error;
-          }
-          sessionTokens = { access_token: accessToken, refresh_token: refreshToken };
-        } else if (queryToken) {
-          const { data, error } = await supabase.auth.verifyOtp({ type: 'recovery', token_hash: queryToken });
-          if (error) {
-            throw error;
-          }
-          sessionTokens = {
-            access_token: data?.session?.access_token,
-            refresh_token: data?.session?.refresh_token,
-          };
-        } else if (queryCode) {
-          const { data, error } = await supabase.auth.exchangeCodeForSession(queryCode);
-          if (error) {
-            throw error;
-          }
-          sessionTokens = {
-            access_token: data?.session?.access_token,
-            refresh_token: data?.session?.refresh_token,
-          };
-        }
-
-        if (!sessionTokens?.access_token || !sessionTokens?.refresh_token) {
-          throw new Error('Missing session tokens from reset link');
-        }
-
-        const persistResponse = await fetch('/api/auth/session', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify(sessionTokens)
-        });
-
-        if (!persistResponse.ok) {
-          const persistError = await persistResponse.json().catch(() => ({}));
-          throw new Error(persistError?.error || 'Unable to store session');
-        }
-
-        if (typeof window !== 'undefined') {
-          window.history.replaceState({}, '', window.location.pathname);
-        }
-
-        setStatus('Link verified. Redirecting…');
-        setTimeout(() => router.replace('/auth/update-password/form'), 300);
-      } catch (error) {
-        console.error('[UpdatePassword] Failed to process reset link:', error);
-        setStatus('Reset link is invalid or has expired. Redirecting…');
-        setTimeout(() => router.replace('/auth/reset-password?error=Invalid or expired reset link'), 1500);
-      }
-    };
-
-    handleRecovery();
-  }, [router, queryKey]);
-
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#faf8f3] to-[#f5f1e8]">
-      <LoadingSpinner message={status} size="default" />
-    </div>
-  );
-}
-
 export default function UpdatePasswordEntryPage() {
   return (
     <Suspense fallback={
@@ -112,7 +10,36 @@ export default function UpdatePasswordEntryPage() {
         <LoadingSpinner message="Loading..." size="default" />
       </div>
     }>
-      <UpdatePasswordContent />
+      <UpdatePasswordRedirector />
     </Suspense>
+  );
+}
+
+function UpdatePasswordRedirector() {
+  const searchParams = useSearchParams();
+  const queryKey = searchParams.toString();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const redirectUrl = new URL(`${window.location.origin}/auth/callback`);
+    redirectUrl.searchParams.set('next', '/auth/update-password/form');
+
+    searchParams.forEach((value, key) => {
+      redirectUrl.searchParams.set(key, value);
+    });
+
+    const currentHash = window.location.hash;
+    if (currentHash) {
+      redirectUrl.hash = currentHash;
+    }
+
+    window.location.replace(redirectUrl.toString());
+  }, [queryKey]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#faf8f3] to-[#f5f1e8]">
+      <LoadingSpinner message="Redirecting…" size="default" />
+    </div>
   );
 }

--- a/lib/supabase-auth.js
+++ b/lib/supabase-auth.js
@@ -170,8 +170,10 @@ export async function resetPassword(email) {
   if (!supabase) {
     return { error: 'Authentication client unavailable' };
   }
+  const nextPath = encodeURIComponent('/auth/update-password/form');
+  const redirectTo = `${getRedirectOrigin()}/auth/callback?next=${nextPath}`;
   const { data, error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${getRedirectOrigin()}/auth/update-password`
+    redirectTo
   });
 
   if (error) {


### PR DESCRIPTION
## Summary
- Simplified password reset flow by redirecting through auth/callback
- Removed complex client-side token validation
- Better production reliability

## Changes
- Refactored `/auth/update-password/page.js` to redirect to `/auth/callback`
- Preserves all query parameters and hash fragments during redirect
- Sets `next` parameter to redirect to update-password form after auth
- Removed all client-side token validation logic

## Test plan
- [x] Test password reset flow with various link formats
- [x] Verify query parameters are preserved
- [x] Confirm hash fragments are maintained
- [x] Test successful redirect to update-password form
- [x] Verify production deployment works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)