### PR TITLE
Ongoing Bug Fixing - OTP Auth Improvements & Login Redirect Fix

### DIFF
--- a/app/api/auth/verify-otp/route.js
+++ b/app/api/auth/verify-otp/route.js
@@ -219,10 +219,26 @@ export async function POST(request) {
       path: '/'
     });
 
+    // Set a short-lived cookie to indicate fresh login
+    console.log('[verify-otp] Setting just-logged-in cookie');
+    cookieStore.set('just-logged-in', '1', {
+      httpOnly: false,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 10, // Only valid for 10 seconds
+      path: '/'
+    });
+
     // Determine redirect based on role
     let redirectTo = '/dashboard';
 
-    if (['client', 'client_admin', 'client_participant'].includes(userProfile.role)) {
+    const adminRoles = ['super_admin', 'project_admin', 'team_member'];
+    const clientRoles = ['client', 'client_admin', 'client_participant'];
+
+    if (adminRoles.includes(userProfile.role)) {
+      // Admin users go directly to admin projects
+      redirectTo = '/admin/projects';
+    } else if (clientRoles.includes(userProfile.role)) {
       // Get user's project
       const { data: projectMember } = await supabase
         .from('aloa_project_members')

--- a/middleware.js
+++ b/middleware.js
@@ -209,6 +209,10 @@ export async function middleware(request) {
       // User just logged in - skip auth cleanup to allow session to establish
       // The cookie expires in 10 seconds, so this is temporary
       console.log('[Middleware] Skipping auth cleanup - just logged in');
+      // Add cache headers to prevent browser from caching redirects
+      response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+      response.headers.set('Pragma', 'no-cache');
+      response.headers.set('Expires', '0');
     } else if (needsAuthCleanup && !isAuthPage) {
       // Not on auth page and have auth issues - redirect
       // Clear all auth-related cookies

--- a/middleware.js
+++ b/middleware.js
@@ -188,10 +188,27 @@ export async function middleware(request) {
     // This is critical for OTP flow to work properly
     const isAuthPage = pathname.startsWith('/auth/') || pathname.startsWith('/forms/');
 
+    // Check if user just logged in (has the just-logged-in cookie)
+    const justLoggedIn = request.cookies.get('just-logged-in');
+
+    // Debug logging
+    if (pathname === '/admin/projects') {
+      console.log('[Middleware] /admin/projects check:', {
+        hasSession: !!session,
+        needsAuthCleanup,
+        justLoggedIn: !!justLoggedIn,
+        cookies: request.cookies.getAll().map(c => c.name)
+      });
+    }
+
     if (isAuthPage) {
       // Already on an auth/public page, just let it through completely
       // This prevents redirect loops and ensures OTP pages remain stable
       // DO NOT perform any auth cleanup or redirects for auth pages
+    } else if (justLoggedIn) {
+      // User just logged in - skip auth cleanup to allow session to establish
+      // The cookie expires in 10 seconds, so this is temporary
+      console.log('[Middleware] Skipping auth cleanup - just logged in');
     } else if (needsAuthCleanup && !isAuthPage) {
       // Not on auth page and have auth issues - redirect
       // Clear all auth-related cookies


### PR DESCRIPTION
## Summary
- Fixed OTP password reset syntax error that was causing internal server error
- Improved OTP login redirect flow to minimize login page flash
- Added middleware protection to prevent premature auth cleanup after login
- Enhanced AuthGuard with retry logic for fresh logins

## Bug Fixes

### 1. OTP Password Reset Fix
- Fixed `.catch()` syntax error in verify-otp-reset endpoint
- Password reset now works correctly without internal server errors

### 2. OTP Login Redirect Improvements
- Added `just-logged-in` cookie to signal fresh login
- Middleware now skips auth cleanup for 10 seconds after login
- AuthGuard includes retry logic when detecting fresh login
- Changed to `window.location.replace()` for cleaner navigation
- Added cache prevention headers

### 3. Authentication Flow Enhancements
- Direct redirect to `/admin/projects` for admin users
- Direct redirect to project dashboard for client users
- Eliminates intermediate `/dashboard` redirect
- Improved session establishment timing

## Test Plan
- [x] Test OTP password reset flow - works without errors
- [x] Test OTP login flow - redirects properly
- [x] Verify middleware skips auth cleanup after login
- [x] Check AuthGuard retry logic for fresh logins
- [x] Confirm no intermediate dashboard redirect

## Notes
While the server-side redirect to login has been eliminated (confirmed in logs), Safari may still briefly show cached content during navigation. This is a browser rendering artifact during full page reload, not an actual redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)